### PR TITLE
feat: introduce shouldRetry() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Plugin for [gemini](https://github.com/gemini-testing/gemini) and [hermione](https://github.com/gemini-testing/hermione/) to disable retries at runtime.
 
+## How it works?
+
+Plugin sets retries threshold. If it’s exceeded test will or will not be retried based on the result of `shouldRetry` function in config.
+
+For Gemini the rule is: if the test ends without result (nor `equal:false` nor `equal:true`) test will be retried if it’s attempts not exceeded.
+
+For Hermione the rule is: no retries.
+
 ## Install
 
 ```bash
@@ -10,12 +18,12 @@ $ npm install retry-limiter
 
 ## Usage
 
-### configuration
+### Configuration
 
 * **enabled** (optional) `Boolean` – enable/disable the plugin; default `true`.
 * **limit** (optional) `Number` – number in range from 0 to 1; if retries count to a total number of tests exceed the specified limit all next tests will be run without retries; default `1`.
 
-### gemini
+### Gemini
 
 Add the plugin to your configuration file:
 
@@ -31,7 +39,7 @@ module.exports = {
 };
 ```
 
-### hermione
+### Hermione
 
 ```js
 module.exports = {

--- a/lib/config-decorator.js
+++ b/lib/config-decorator.js
@@ -1,17 +1,18 @@
 'use strict';
 
 module.exports = class ConfigDecorator {
-    static create(config) {
-        return new ConfigDecorator(config);
+    static create(config, retryRule) {
+        return new ConfigDecorator(config, retryRule);
     }
 
-    constructor(config) {
+    constructor(config, retryRule) {
         this._config = config;
+        this._retryRule = retryRule;
     }
 
     disableRetries() {
         this._config.getBrowserIds().forEach((browserId) => {
-            this._config.forBrowser(browserId).retry = 0;
+            this._config.forBrowser(browserId).shouldRetry = this._retryRule;
         });
     }
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,3 +17,8 @@ exports.stubOpts = (opts) => {
         enabled: true
     });
 };
+
+exports.createConfigStub = (browsers) => ({
+    getBrowserIds: sinon.stub().returns(_.keys(browsers)),
+    forBrowser: sinon.stub().callsFake((id) => browsers[id])
+});


### PR DESCRIPTION
Changed behaviour of the plugin. Reason: fail tests was without diff. It’s
annoying for restart gemini/hermione to get any diff and be able to fix tests.

Before this commit: retry-limiter set "retry" from Gemini/Hermione config to zero.

After this commit: retry-limiter rewrite `shouldRetry()` method from config. For
Gemini and Hermione `shouldRetry()` determines different behavior.

New Gemini `shouldRetry()` method does:
  * allow retries for test without result despite the total retries limit was exceeded
  * disallow retry for test with result because the total retries limit was exceeded
  * disallow retry for test without result because the test’s attempts was run out
  * disallow retry for test with result because the test’s attempts was run out

New Hermione `shouldRetry()` method always returns `false`.

See: FEI-8660