### PR TITLE
feat: hermione: subscribe on AFTER_TESTS_READ instead of AFTER_FILE_READ and BEGIN

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Plugin for gemini and hermione to disable retries at runtime",
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && npm run test-unit",
+    "test": "npm run test-unit && npm run lint",
     "test-unit": "mocha test"
   },
   "repository": {


### PR DESCRIPTION
works with `hermione@0.73.0+`